### PR TITLE
Migrate from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+
+name: Build
+
+jobs:
+
+  docker-build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: |
+          docker build -t ghcr.io/spaceapi-community/spaceapi-sensor-logger:latest .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Docker image
         run: |
-          docker build -t spaceapi/influxdb-sensor-logger:latest .
+          docker build -t ghcr.io/spaceapi-community/spaceapi-sensor-logger:latest .
 
   docker-publish:
     name: Publish Docker image
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Docker image
         run: |
           docker build \
             --no-cache \
-            -t spaceapi/influxdb-sensor-logger:latest \
-            -t spaceapi/influxdb-sensor-logger:v1 \
+            -t ghcr.io/spaceapi-community/spaceapi-sensor-logger:latest \
+            -t ghcr.io/spaceapi-community/spaceapi-sensor-logger:v1 \
+            --label "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
             .
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker image
         run: |
-          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" && \
-          docker push -a spaceapi/influxdb-sensor-logger
+          docker push -a ghcr.io/spaceapi-community/spaceapi-sensor-logger

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - chore-ghcr
   schedule:
     - cron: '30 3 * * 2'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,26 +1,18 @@
 on:
   push:
+    branches:
+      - master
+      - chore-ghcr
   schedule:
     - cron: '30 3 * * 2'
 
-name: CI
+name: Publish
 
 jobs:
-
-  docker-build:
-    name: Build Docker image
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Docker image
-        run: |
-          docker build -t ghcr.io/spaceapi-community/spaceapi-sensor-logger:latest .
 
   docker-publish:
     name: Publish Docker image
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker image

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpaceAPI InfluxDB Sensor Logger
 
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/spaceapi/influxdb-sensor-logger/latest)](https://hub.docker.com/r/spaceapi/influxdb-sensor-logger)
+[![Docker Image][docker-image-badge]][docker-image]
 
 A Python 3 script to relay sensor values from a SpaceAPI endpoint to an
 InfluxDB instance so it can be viewed in Grafana.
@@ -41,7 +41,7 @@ Configure it using the following env vars:
 - `SPACEAPI_ENDPOINT`
 - `RELAY_INTERVAL_SECONDS`
 
-The image is published at [docker.io/spaceapi/influxdb-sensor-logger](https://hub.docker.com/r/spaceapi/influxdb-sensor-logger).
+The image is published at [ghcr.io/spaceapi-community/spaceapi-sensor-logger](https://ghcr.io/spaceapi-community/spaceapi-sensor-logger).
 
 
 ## License
@@ -60,3 +60,6 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
 license, shall be dual licensed as above, without any additional terms or
 conditions.
+
+[docker-image]: https://ghcr.io/spaceapi-community/spaceapi-sensor-logger
+[docker-image-badge]: https://img.shields.io/badge/container%20image-ghcr.io/spaceapi-community/spaceapi-sensor-logger-blue.svg


### PR DESCRIPTION
- Split `ci` workflow into two:
  - `build` run successfully here: https://github.com/spaceapi-community/spaceapi-sensor-logger/actions/runs/13141630334
  - `publish` run successfully here: https://github.com/spaceapi-community/spaceapi-sensor-logger/actions/runs/13141630332
- Image: [ghcr.io/spaceapi-community/spaceapi-sensor-logger](https://ghcr.io/spaceapi-community/spaceapi-sensor-logger)